### PR TITLE
Add support for setuptools_scm_git_archive

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+git_archival.txt  export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-git_archival.txt  export-subst
+.git_archival.txt  export-subst

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ from Cython.Distutils import build_ext
 from distutils.extension import Extension
 
 
-install_requires = ['Cython', 'pysam']
-setup_requires   = ['pytest-runner', 'pysam', 'setuptools_scm==1.15.0', 'setuptools_scm_git_archive==1.0']
-tests_require    = ['pytest', 'coverage']
+install_requires = ['pysam']
+setup_requires   = ['pysam', 'setuptools_scm==1.15.0', 'setuptools_scm_git_archive==1.0']
+tests_require    = ['pytest-runner', 'pytest', 'coverage']
 
 
 ext_modules = [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from distutils.extension import Extension
 
 
 install_requires = ['Cython', 'pysam']
-setup_requires   = ['pytest-runner', 'pysam', 'setuptools_scm==1.15.0']
+setup_requires   = ['pytest-runner', 'pysam', 'setuptools_scm==1.15.0', 'setuptools_scm_git_archive==1.0']
 tests_require    = ['pytest', 'coverage']
 
 


### PR DESCRIPTION
`setuptools_scm` does not work correctly with archives downloaded from Github. `setuptools_scm_git_archive` and the few changes made to the repository work around this limitation. The end result is an archive that can be downloaded and used as a source for a [bioconda](bioconda.github.io/recipes.html) recipe.

If this PR is accepted and a tag added, the resulting Github archive will be usable. For now the `bioconda` recipe is using a git checkout.