### PR TITLE
Fix for empty VCF files

### DIFF
--- a/vgraph/dbmatch.py
+++ b/vgraph/dbmatch.py
@@ -184,9 +184,9 @@ def match_database2(args):
     except TypeError:
         sample_name = args.name
 
-    if not db.index:
+    if db.index is None:
         raise ValueError('database file must be indexed')
-    if not sample.index:
+    if sample.index is None:
         raise ValueError('sample file must be indexed')
 
     # Open tabluar output file, if requested

--- a/vgraph/match.py
+++ b/vgraph/match.py
@@ -58,7 +58,7 @@ def all_contigs(varfiles):
 
     """
     contigs = list(varfiles.header.contigs)
-    if varfiles.index:
+    if varfiles.index is not None:
         contigs.extend(varfiles.index)
     return unique_everseen(contigs)
 
@@ -73,7 +73,7 @@ def informative_contigs(varfile):
         All contigs that have data
 
     """
-    if not varfile.index:
+    if varfile.index is None:
         raise ValueError('Variant file requires index')
     return (contig for contig in varfile.index if not is_empty_iter(varfile.fetch(contig)))
 


### PR DESCRIPTION
VariantFile.index is dict-like, so tests for the existance of an index must compare it to None