### PR TITLE
Bfx 942 kbj rework ar

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ ignore_missing_imports = True
 minversion = 2.8
 addopts = -n 4
           --flake8
-          --doctest-module
+          --doctest-modules
           --cov-report term
           --cov-report html:build/coverage
           --cov=vgraph

--- a/vgraph/match.py
+++ b/vgraph/match.py
@@ -272,26 +272,65 @@ def path_allele_counts(paths):
 def path_to_ads(path, counts):
     """Convert a path through a variant graph into a sequence of allele depths."""
     for p, c in zip(path, counts):
+        # Skip nodes with no VCF record
         if not p.locus:
             continue
         record = p.locus.record
         sample = record.samples[0]
         dp     = sample['AD'][p.index] if 'AD' in sample and p.index is not None else sample.get('MIN_DP', 0)
-        yield dp / c[p.index]
+        yield dp // c[p.index]
 
 
 def path_to_ref_ads(path):
     """Convert a path through a variant graph into a sequence of reference allele depths."""
     for p in path:
+        # Skip nodes with no VCF record
         if not p.locus:
             continue
         record = p.locus.record
         sample = record.samples[0]
-        dp     = sample['AD'][0] if 'AD' in sample else sample.get('MIN_DP', 0)
-        yield dp
+        yield sample['AD'][0] if 'AD' in sample else sample.get('MIN_DP', 0)
+
+
+def build_match_result(geno, matches, super_ref):
+    """Build match results."""
+    seqs, paths   = zip(*geno)
+    allele_counts = list(path_allele_counts(paths))
+    allele_depths = [list(path_to_ads(path, allele_counts)) for path in paths]
+
+    found, ref, other = [], [], []
+    for m, seq, ad in zip(matches, seqs, allele_depths):
+        if m:
+            found.append(ad)
+        elif fancy_match(super_ref, seq):
+            ref.append(ad)
+        else:
+            other.append(ad)
+
+    ref_ploidy    = len(ref)
+    allele_ploidy = len(found)
+    other_ploidy  = len(other)
+
+    # If a reference allele was not called, then collect all reference allele depths
+    # from an arbitrary path, as AD always contains reference counts.
+    if not ref_ploidy and paths:
+        ref = [list(path_to_ref_ads(paths[0]))]
+
+    allele_ad     = empty_min(chain.from_iterable(found), default=None)
+    ref_ad        = empty_min(chain.from_iterable(ref),   default=None)
+    other_ad      = empty_min(chain.from_iterable(other), default=None)
+
+    return AlleleMatch(allele_ploidy, allele_ad, ref_ploidy, ref_ad, other_ploidy, other_ad)
 
 
 nothing = object()
+
+
+def empty_min(items, default=nothing):
+    items = list(items)
+    if not items and default is not nothing:
+        return default
+    return min(items)
 
 
 def int_mean(items, default=nothing):
@@ -399,31 +438,7 @@ def find_allele_matches(ref, start, stop, allele, genos, ploidy, mode, debug=Fal
     if not zygosity and nocalls:
         return None
 
-    seqs, paths   = zip(*geno)
-    allele_counts = list(path_allele_counts(paths))
-    allele_depths = [list(path_to_ads(path, allele_counts)) for path in paths]
-
-    found, ref, other = [], [], []
-    for m, seq, ad in zip(matches, seqs, allele_depths):
-        if m:
-            found.append(ad)
-        elif fancy_match(super_ref, seq):
-            ref.append(ad)
-        else:
-            other.append(ad)
-
-    ref_ploidy    = len(ref)
-    allele_ploidy = len(found)
-    other_ploidy  = len(other)
-
-    # If a reference allele was not called, then collect all reference allele depths
-    # from an arbitrary path, as AD always contains reference counts.
-    if not ref and paths:
-        ref = [list(path_to_ref_ads(paths[0]))]
-
-    allele_ad     = int_mean([sum(p) for p in zip(*found)], None)
-    ref_ad        = int_mean([sum(p) for p in zip(*ref)],   None)
-    other_ad      = int_mean([sum(p) for p in zip(*other)], None)
+    result = build_match_result(geno, matches, super_ref)
 
     if debug:
         for super_allele in super_alleles:
@@ -432,11 +447,14 @@ def find_allele_matches(ref, start, stop, allele, genos, ploidy, mode, debug=Fal
             print('   GENO{:02d}:{} {}'.format(i, tuple(map(len, g)),  g), file=sys.stderr)
             print(f'  MATCH{i:02d}: {m}', file=sys.stderr)
         print(file=sys.stderr)
-        print(f'ALLELE: id={allele.record.id}, allele_ploidy={allele_ploidy}, ref_ploidy={ref_ploidy}, other_ploidy={other_ploidy}, ploidy={ploidy}',
-              file=sys.stderr)
+        print(
+            f'ALLELE: id={allele.record.id}, allele_ploidy={result.allele_ploidy}, '
+            f'ref_ploidy={result.ref_ploidy}, other_ploidy={result.other_ploidy}, ploidy={result.ploidy}',
+            file=sys.stderr
+        )
         print(f'  ZYGOSITY: {zygosity}', file=sys.stderr)
 
-    return AlleleMatch(allele_ploidy, allele_ad, ref_ploidy, ref_ad, other_ploidy, other_ad)
+    return result
 
 
 def find_allele(ref, allele, superlocus, mode='sensitive', debug=False):

--- a/vgraph/match.py
+++ b/vgraph/match.py
@@ -304,7 +304,7 @@ def build_match_result(geno, matches, super_ref):
     for m, seq, ad in zip(matches, seqs, allele_depths):
         if m:
             found.append(ad)
-        elif fancy_match(super_ref, seq):
+        elif seq == super_ref:  # no need for fancy_match; super_ref has no wildcards
             ref.append(ad)
         else:
             other.append(ad)
@@ -349,10 +349,11 @@ def build_match_strings(ref, start, stop, allele, mode='sensitive', debug=False)
             ','.join(alts),
         ), file=sys.stderr)
 
+    super_ref = normalize_seq(ref[start:stop])
+
     # Require reference matches within the wobble zone + padding built into each normalized allele
     if mode == 'specific':
         super_alleles = [normalize_seq(ref[start:allele.start] + alt + ref[allele.stop:stop]) for alt in alts]
-        super_ref     = normalize_seq(ref[start:stop])
     elif mode == 'sensitive':
         super_alleles = [
             normalize_seq(
@@ -363,12 +364,6 @@ def build_match_strings(ref, start, stop, allele, mode='sensitive', debug=False)
                 + '*' * (stop - allele.max_stop)
             ) for alt in alts
         ]
-
-        super_ref = normalize_seq(
-            '*' * (allele.min_start - start)
-            + ref[allele.min_start:allele.max_stop]
-            + '*' * (stop - allele.max_stop)
-        )
     else:
         raise ValueError(f'invalid match mode specified: {mode}')
 


### PR DESCRIPTION
Fix two bugs in the haplotype counting and read depth code used by the dbmatch2 command.  These resulted in cases where the ploidies or read depths were incorrect (i.e. match annotations), but did not alter any matches:

  1. The allele depth code was not smart enough when computing reference read counts when no fully-reference haplotypes were called.
  2. The reference haplotype counting was overly permissive in matching reference, which resulted in some cases where the reference haplotype count was too high at the expense of "other" haplotypes.

As a side-effect of the above fixes, the read counter will no longer take the mean of allele depths across each haplotype.  This new version takes minimums over the entire haplotype instead.  As these are both imperfect approximations, there will be cases where one works seems to work better than the other.  However, the changes to the counts will generally be minor.  The choice to switch from mean to minimum was not abitrary, but is intended to simplify the code and avoid (more) edge cases.